### PR TITLE
Fix multi-selection

### DIFF
--- a/iron-multi-selectable.html
+++ b/iron-multi-selectable.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <script>
 
   Polymer.IronMultiSelectableBehavior = [
-    Polymer.IronSelectableBehavior, {
+    {
 
       properties: {
 
@@ -121,7 +121,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this._selection.setItemSelected(this._valueToItem(value), unselected);
       }
 
-    }
+    }, Polymer.IronSelectableBehavior
   ];
 
 </script>


### PR DESCRIPTION
`IronMultiSelectableBehavior` was picking up the selection behaviour from `IronSelectableBehavior` instead of using its own. The `multi` tests were actually failing to show this, and now they're green! :tada: 

/cc @morethanreal 