### PR TITLE
Correct IronMultiSelectableBehavior arrangement.

### DIFF
--- a/iron-multi-selectable.html
+++ b/iron-multi-selectable.html
@@ -1,4 +1,5 @@
 <!--
+@license
 Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
 This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
 The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
@@ -12,117 +13,118 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 
-  /** @polymerBehavior */
-  Polymer.IronMultiSelectableBehavior = [
-    {
-
-      properties: {
-
-        /**
-         * If true, multiple selections are allowed.
-         *
-         * @attribute multi
-         * @type Boolean
-         * @default false
-         */
-        multi: {
-          type: Boolean,
-          value: false,
-          observer: 'multiChanged'
-        },
-
-        /**
-         * Gets or sets the selected elements. This is used instead of `selected` when `multi`
-         * is true.
-         *
-         * @attribute selectedValues
-         * @type Array
-         */
-        selectedValues: {
-          type: Array,
-          notify: true
-        },
-
-        /**
-         * Returns an array of currently selected items.
-         *
-         * @attribute selectedItems
-         * @type Array
-         */
-        selectedItems: {
-          type: Array,
-          readOnly: true,
-          notify: true
-        },
-
-      },
-
-      observers: [
-        '_updateSelected(attrForSelected, selectedValues)'
-      ],
+  Polymer.IronMultiSelectableBehaviorImpl = {
+    properties: {
 
       /**
-       * Selects the given value. If the `multi` property is true, then the selected state of the
-       * `value` will be toggled; otherwise the `value` will be selected.
+       * If true, multiple selections are allowed.
        *
-       * @method select
-       * @param {string} value the value to select.
+       * @attribute multi
+       * @type Boolean
+       * @default false
        */
-      select: function(value) {
-        if (this.multi) {
-          if (this.selectedValues) {
-            this._toggleSelected(value);
-          } else {
-            this.selectedValues = [value];
-          }
+      multi: {
+        type: Boolean,
+        value: false,
+        observer: 'multiChanged'
+      },
+
+      /**
+       * Gets or sets the selected elements. This is used instead of `selected` when `multi`
+       * is true.
+       *
+       * @attribute selectedValues
+       * @type Array
+       */
+      selectedValues: {
+        type: Array,
+        notify: true
+      },
+
+      /**
+       * Returns an array of currently selected items.
+       *
+       * @attribute selectedItems
+       * @type Array
+       */
+      selectedItems: {
+        type: Array,
+        readOnly: true,
+        notify: true
+      },
+
+    },
+
+    observers: [
+      '_updateSelected(attrForSelected, selectedValues)'
+    ],
+
+    /**
+     * Selects the given value. If the `multi` property is true, then the selected state of the
+     * `value` will be toggled; otherwise the `value` will be selected.
+     *
+     * @method select
+     * @param {string} value the value to select.
+     */
+    select: function(value) {
+      if (this.multi) {
+        if (this.selectedValues) {
+          this._toggleSelected(value);
         } else {
-          this.selected = value;
+          this.selectedValues = [value];
         }
-      },
-
-      multiChanged: function(multi) {
-        this._selection.multi = multi;
-      },
-
-      _updateSelected: function() {
-        if (this.multi) {
-          this._selectMulti(this.selectedValues);
-        } else {
-          this._selectSelected(this.selected);
-        }
-      },
-
-      _selectMulti: function(values) {
-        this._selection.clear();
-        if (values) {
-          for (var i = 0; i < values.length; i++) {
-            this._selection.setItemSelected(this._valueToItem(values[i]), true);
-          }
-        }
-      },
-
-      _selectionChange: function() {
-        var s = this._selection.get();
-        if (this.multi) {
-          this._setSelectedItems(s);
-        } else {
-          this._setSelectedItems([s]);
-          this._setSelectedItem(s);
-        }
-      },
-
-      _toggleSelected: function(value) {
-        var i = this.selectedValues.indexOf(value);
-        var unselected = i < 0;
-        if (unselected) {
-          this.selectedValues.push(value);
-        } else {
-          this.selectedValues.splice(i, 1);
-        }
-        this._selection.setItemSelected(this._valueToItem(value), unselected);
+      } else {
+        this.selected = value;
       }
+    },
 
-    }, Polymer.IronSelectableBehavior
+    multiChanged: function(multi) {
+      this._selection.multi = multi;
+    },
+
+    _updateSelected: function() {
+      if (this.multi) {
+        this._selectMulti(this.selectedValues);
+      } else {
+        this._selectSelected(this.selected);
+      }
+    },
+
+    _selectMulti: function(values) {
+      this._selection.clear();
+      if (values) {
+        for (var i = 0; i < values.length; i++) {
+          this._selection.setItemSelected(this._valueToItem(values[i]), true);
+        }
+      }
+    },
+
+    _selectionChange: function() {
+      var s = this._selection.get();
+      if (this.multi) {
+        this._setSelectedItems(s);
+      } else {
+        this._setSelectedItems([s]);
+        this._setSelectedItem(s);
+      }
+    },
+
+    _toggleSelected: function(value) {
+      var i = this.selectedValues.indexOf(value);
+      var unselected = i < 0;
+      if (unselected) {
+        this.selectedValues.push(value);
+      } else {
+        this.selectedValues.splice(i, 1);
+      }
+      this._selection.setItemSelected(this._valueToItem(value), unselected);
+    }
+  };
+
+  /** @polymerBehavior */
+  Polymer.IronMultiSelectableBehavior = [
+    Polymer.IronSelectableBehavior,
+    Polymer.IronMultiSelectableBehaviorImpl
   ];
 
 </script>


### PR DESCRIPTION
This change moves `IronMultiSelectableBehaviorImpl` out of an array, and also corrects the order in which its dependencies are arranged in the `IronMultiSelectableBehavior` array to accommodate for https://github.com/Polymer/polymer/commit/fba14a3317f19a6bb5cf3acb5b4a8f42b9f74876

/cc @notwaldorf @morethanreal 