### PR TITLE
Use tap event

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -59,11 +59,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        *
        * @attribute activateEvent
        * @type {string}
-       * @default 'click'
+       * @default 'tap'
        */
       activateEvent: {
         type: String,
-        value: 'click',
+        value: 'tap',
         observer: '_activateEventChanged'
       },
 

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -109,7 +109,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     created: function() {
-      this._bindActivateHandler = this._activateHandler.bind(this);
       this._bindFilterItem = this._filterItem.bind(this);
       this._selection = new Polymer.IronSelection(this._applySelection.bind(this));
     },
@@ -183,11 +182,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _addListener: function(eventName) {
-      this.addEventListener(eventName, this._bindActivateHandler);
+      this.listen(this, eventName, '_activateHandler');
     },
 
     _removeListener: function(eventName) {
-      this.removeEventListener(eventName, this._bindActivateHandler);
+      // There is no unlisten yet...
+      // https://github.com/Polymer/polymer/issues/1639
+      //this.removeEventListener(eventName, this._bindActivateHandler);
     },
 
     _activateEventChanged: function(eventName, old) {

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -277,6 +277,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _activateHandler: function(e) {
+      // TODO: remove this when https://github.com/Polymer/polymer/issues/1639 is fixed so we
+      // can just remove the old event listener.
+      if (e.type !== this.activateEvent) {
+        return;
+      }
       var t = e.target;
       var items = this.items;
       while (t && t != this) {

--- a/test/activate-event.html
+++ b/test/activate-event.html
@@ -52,15 +52,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         s = fixture('test');
       });
 
-      test('activates on click', function() {
+      test('activates on tap', function() {
         assert.equal(s.selected, '0');
 
         // select Item 1
-        s.children[1].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[1].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         assert.equal(s.selected, '1');
       });
 
-      test('activates on click and fires iron-activate', function(done) {
+      test('activates on tap and fires iron-activate', function(done) {
         assert.equal(s.selected, '0');
 
         // attach iron-activate listener
@@ -71,10 +71,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         // select Item 1
-        s.children[1].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[1].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
       });
 
-      test('click on already selected and fires iron-activate', function(done) {
+      test('tap on already selected and fires iron-activate', function(done) {
         assert.equal(s.selected, '0');
 
         // attach iron-activate listener
@@ -85,7 +85,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         // select Item 0
-        s.children[0].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[0].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
       });
 
       test('activates on mousedown', function() {
@@ -119,13 +119,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(s.selected, '0');
       });
 
-      test('activates on click and preventDefault', function() {
+      test('activates on tap and preventDefault', function() {
         // attach iron-activate listener
         s.addEventListener("iron-activate", function(event) {
           event.preventDefault();
         });
         // select Item 2
-        s.children[2].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[2].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         // shouldn't got selected since we preventDefault in iron-activate
         assert.equal(s.selected, '0');
       });

--- a/test/basic.html
+++ b/test/basic.html
@@ -83,8 +83,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isFalse(s1.multi);
       });
 
-      test('to click as activateEvent', function() {
-        assert.equal(s1.activateEvent, 'click');
+      test('to tap as activateEvent', function() {
+        assert.equal(s1.activateEvent, 'tap');
       });
 
       test('to nothing as attrForSelected', function() {

--- a/test/content.html
+++ b/test/content.html
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('activate event', function() {
         var item = s1.querySelector('#item2');
-        item.dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        item.dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         // check selected class
         assert.isTrue(item.classList.contains('iron-selected'));
       });
@@ -122,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('activate event', function() {
         var item = s2.querySelector('#item2');
-        item.dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        item.dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         // check selected class
         assert.isTrue(item.classList.contains('iron-selected'));
       });

--- a/test/multi.html
+++ b/test/multi.html
@@ -77,8 +77,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('set multi-selection via tap', function() {
         // set selectedValues
-        s.children[0].dispatchEvent(new CustomEvent('click', {bubbles: true}));
-        s.children[2].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[0].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
+        s.children[2].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         // check selected class
         assert.isTrue(s.children[0].classList.contains('iron-selected'));
         assert.isTrue(s.children[2].classList.contains('iron-selected'));
@@ -100,12 +100,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           deselectEventCounter++;
         });
         // tap to select an item
-        s.children[0].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[0].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         // check events
         assert.equal(selectEventCounter, 1);
         assert.equal(deselectEventCounter, 0);
         // tap on already selected item should deselect it
-        s.children[0].dispatchEvent(new CustomEvent('click', {bubbles: true}));
+        s.children[0].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
         // check selectedValues
         assert.equal(s.selectedValues.length, 0);
         // check class


### PR DESCRIPTION
Switch `click` to `tap` as the default value for `activateEvent`.  In order to listen for gesture events such as `tap` we need to use `Polymer.Base.listen`.  But currently there is no `Polymer.Base.unlisten` (https://github.com/Polymer/polymer/issues/1639).  So in order to workaround this we need to make `_activateHandler` to ignore old events.

This should help elements like `paper-menu` working on mobile.