### PR TITLE
Use Polymer array functions to allow selectedValues observation

### DIFF
--- a/iron-multi-selectable.html
+++ b/iron-multi-selectable.html
@@ -103,9 +103,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var i = this.selectedValues.indexOf(value);
       var unselected = i < 0;
       if (unselected) {
-        this.selectedValues.push(value);
+        this.push('selectedValues', value);
       } else {
-        this.selectedValues.splice(i, 1);
+        this.splice('selectedValues', i, 1);
       }
       this._selection.setItemSelected(this._valueToItem(value), unselected);
     }


### PR DESCRIPTION
Using `this.push` and `this.splice` to allow selectedValues to be observed via a path observer. Otherwise, there is no proper way to listen to `selectedValues.*`.