### PR TITLE
Enable _removeListener after Polymer/polymer#1740

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -186,9 +186,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _removeListener: function(eventName) {
-      // There is no unlisten yet...
-      // https://github.com/Polymer/polymer/issues/1639
-      //this.removeEventListener(eventName, this._bindActivateHandler);
+      this.unlisten(this, eventName, '_activateHandler');
     },
 
     _activateEventChanged: function(eventName, old) {
@@ -277,11 +275,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _activateHandler: function(e) {
-      // TODO: remove this when https://github.com/Polymer/polymer/issues/1639 is fixed so we
-      // can just remove the old event listener.
-      if (e.type !== this.activateEvent) {
-        return;
-      }
       var t = e.target;
       var items = this.items;
       while (t && t != this) {


### PR DESCRIPTION
Polymer/polymer#1740 adds `unlisten` functionality, thus fixing blocking issue Polymer/polymer#1639. Now `iron-selector` can properly remove the event listener for the old activate event when it is changed instead of being forced to ignore unwanted handler calls.