### PR TITLE
Fixed notification of selectionValue array items

### DIFF
--- a/iron-multi-selectable.html
+++ b/iron-multi-selectable.html
@@ -61,10 +61,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         if (this.selectedValues) {
           this._toggleSelected(value);
         } else {
-          this.selectedValues = [value];
+          this.set('selectedValues', [value]);
         }
       } else {
-        this.selected = value;
+        this.set('selected', value);
       }
     },
 
@@ -103,9 +103,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var i = this.selectedValues.indexOf(value);
       var unselected = i < 0;
       if (unselected) {
-        this.selectedValues.push(value);
+        this.push('selectedValues', value);
       } else {
-        this.selectedValues.splice(i, 1);
+        this.splice('selectedValues', i, 1);
       }
       this._selection.setItemSelected(this._valueToItem(value), unselected);
     }

--- a/test/multi.html
+++ b/test/multi.html
@@ -115,6 +115,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(deselectEventCounter, 1);
       });
 
+      test('notify multi-selection values', function() {
+        // check that bound value was updated
+        var selected;
+        s.addEventListener('selected-values-changed', function(e) {
+          if (e.detail.path) {
+            if (e.detail.path === 'selectedValues.splices') {
+              e.detail.value.indexSplices.forEach(function(s) {
+                selected = s.object;
+              });
+            }
+          } else if (e.detail.value) {
+            selected = e.detail.value;
+          }
+        });
+        // set selectedValues
+        s.children[0].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
+        assert.equal(selected.length, 1);
+        s.children[2].dispatchEvent(new CustomEvent('tap', {bubbles: true}));
+        assert.equal(selected.length, 2);
+      });
+
       /* test('toggle multi from true to false', function() {
         // set selected
         s.selected = [0, 2];


### PR DESCRIPTION
The following use-case was not working, as notifications were not being sent for `selectedValues` items 
```html
      <div>
        <h4>Multi-select</h4>
        <div class="horizontal-section">
          <paper-menu id="menu" multi selected-values="{{selected}}">
            <paper-item>Bold</paper-item>
            <paper-item>Italic</paper-item>
            <paper-item>Underline</paper-item>
            <paper-item>Strikethrough</paper-item>
          </paper-menu>
        </div>
      </div>
      <div>
        <h4>Selected items:</h4>
        <div class="horizontal-section">
          <ul>
            <template is="dom-repeat" items="{{selected}}">
              <li>{{item}}</li>
            </template>
          </ul>
        </div>
      </div>
```