### PR TITLE
Add failing tests: `selected` property should be unset when removing the selected item from the DOM

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -100,8 +100,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         s1.selected = 4;
         expect(s1.items.length).to.be.equal(5);
         s1.removeChild(lastElement);
-        expect(s1.items.length).to.be.equal(4);
-        expect(s1.selected).to.not.exist;
+        Polymer.Base.async(function() {
+          expect(s1.items.length).to.be.equal(4);
+          expect(s1.selected).to.not.exist;
+          done();
+        }, 1);
       });
     });
 
@@ -178,7 +181,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(s2.selected).to.be.equal('item2');
           var item2 = s2.querySelector('#item2');
           s2.removeChild(item2);
-          expect(s2.selected).to.not.exist;
+          Polymer.Base.async(function() {
+            expect(s2.selected).to.not.exist;
+            done();
+          }, 1);
         });
         
       });

--- a/test/basic.html
+++ b/test/basic.html
@@ -94,6 +94,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('as many items as children', function() {
         assert.equal(s1.items.length, s1.querySelectorAll('div').length);
       });
+      
+      test('removing the last element when it is selected unsets the value', function() {
+        var lastElement = s1.querySelector(':last-child');
+        s1.selected = 4;
+        expect(s1.items.length).to.be.equal(5);
+        s1.removeChild(lastElement);
+        expect(s1.items.length).to.be.equal(4);
+        expect(s1.selected).to.not.exist;
+      });
     });
 
     suite('basic', function() {
@@ -164,6 +173,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }, 1);
           }, 1);
         });
+        
+        test('removing the selected item unsets the selected value', function () {
+          expect(s2.selected).to.be.equal('item2');
+          var item2 = s2.querySelector('#item2');
+          s2.removeChild(item2);
+          expect(s2.selected).to.not.exist;
+        });
+        
       });
     });
 


### PR DESCRIPTION
Failing tests for cases described in #65 