### PR TITLE
Remove extra type annotation

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -108,7 +108,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * The set of excluded elements where the key is the `localName`
        * of the element that will be ignored from the item list.
        *
-       * @type {object}
        * @default {template: 1}
        */
       _excludedLocalNames: {


### PR DESCRIPTION
(Also the type is spelled Object. Yes this is confusing, as all the other built in types are spelled lowercase. ✨)