### PR TITLE
Observe nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: node_js
+sudo: false
+matrix:
+  include:
+  - node_js: stable
+    script: xvfb-run wct
+    addons:
+      firefox: latest
+      apt:
+        sources:
+        - google-chrome
+        packages:
+        - google-chrome-stable
+  - node_js: node
+    script:
+    - |
+      if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+        wct -s 'default'
+      fi
+before_script:
+- npm install web-component-tester
+- npm install bower
+- export PATH=$PWD/node_modules/.bin:$PATH
+- bower install
+env:
+  global:
+  - secure: ltCkwJM0nkTS9WjikyjqBsB5J2hQon4UnVVrINk4y+Vq4v9PQJH3+83nya0jnxilKaeAJs4d2/OS02F9GkqYpsSmDz7OgXPfk0hrHA8UksvvpSALfnukleIAN2YTOcxXJKeNHcfpqCKPk1dGeNQOEM61H+QgTBIyFB3sMugygqs=
+  - secure: TJuu1WdpFLTaBN/prBafm8Pld/BQCySNuuG1nATbF3fqiOpgehXu8Z5URAz5syUhqZAyEmuRMxvXpEVD/t1jrtaXVwkdCFkkQ4ckkP4gTIeSGA/Puw8sveB2q7QAqXyTmeFkocNlh8fxV+B07o0SPWdhcvdZnDVU9VrpSqL+92M=

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/PolymerElements/iron-selector",
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0"
+    "polymer": "Polymer/polymer#^1.2.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/iron-multi-selectable.html
+++ b/iron-multi-selectable.html
@@ -72,6 +72,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._selection.multi = multi;
     },
 
+    get _shouldUpdateSelection() {
+      return this.selected != null ||
+        (this.selectedValues != null && this.selectedValues.length);
+    },
+
     _updateSelected: function() {
       if (this.multi) {
         this._selectMulti(this.selectedValues);

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -64,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * Returns the currently selected item.
-       * 
+       *
        * @type {?Object}
        */
       selectedItem: {
@@ -107,6 +107,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * The list of items from which a selection can be made.
+       */
+      items: {
+        type: Array,
+        readOnly: true,
+        value: function() {
+          return [];
+        }
+      },
+
+      /**
        * The set of excluded elements where the key is the `localName`
        * of the element that will be ignored from the item list.
        *
@@ -133,7 +144,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     attached: function() {
       this._observer = this._observeItems(this);
-      this._contentObserver = this._observeContent(this);
+      this._updateItems();
       if (!this.selectedItem && this.selected) {
         this._updateSelected(this.attrForSelected,this.selected)
       }
@@ -142,23 +153,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     detached: function() {
       if (this._observer) {
-        this._observer.disconnect();
-      }
-      if (this._contentObserver) {
-        this._contentObserver.disconnect();
+        Polymer.dom(this).unobserveNodes(this._observer);
       }
       this._removeListener(this.activateEvent);
-    },
-
-    /**
-     * Returns an array of selectable items.
-     *
-     * @property items
-     * @type Array
-     */
-    get items() {
-      var nodes = Polymer.dom(this).queryDistributedElements(this.selectable || '*');
-      return Array.prototype.filter.call(nodes, this._bindFilterItem);
     },
 
     /**
@@ -214,6 +211,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _activateEventChanged: function(eventName, old) {
       this._removeListener(old);
       this._addListener(eventName);
+    },
+
+    _updateItems: function() {
+      var nodes = Polymer.dom(this).queryDistributedElements(this.selectable || '*');
+      nodes = Array.prototype.filter.call(nodes, this._bindFilterItem);
+      this._setItems(nodes);
     },
 
     _updateSelected: function() {
@@ -274,18 +277,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._setSelectedItem(this._selection.get());
     },
 
-    // observe content changes under the given node.
-    _observeContent: function(node) {
-      var content = node.querySelector('content');
-      if (content && content.parentElement === node) {
-        return this._observeItems(node.domHost);
-      }
-    },
-
     // observe items change under the given node.
     _observeItems: function(node) {
-      // TODO(cdata): Update this when we get distributed children changed.
-      var observer = new MutationObserver(function(mutations) {
+      return Polymer.dom(node).observeNodes(function(mutations) {
         // Let other interested parties know about the change so that
         // we don't have to recreate mutation observers everywher.
         this.fire('iron-items-changed', mutations, {
@@ -293,15 +287,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           cancelable: false
         });
 
+        this._updateItems();
+
         if (this.selected != null) {
           this._updateSelected();
         }
       }.bind(this));
-      observer.observe(node, {
-        childList: true,
-        subtree: true
-      });
-      return observer;
     },
 
     _activateHandler: function(e) {

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -129,9 +129,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     created: function() {
       this._bindFilterItem = this._filterItem.bind(this);
       this._selection = new Polymer.IronSelection(this._applySelection.bind(this));
-      // TODO(cdata): When polymer/polymer#2535 lands, we do not need to do this
-      // book keeping anymore:
-      this.__listeningForActivate = false;
     },
 
     attached: function() {
@@ -207,17 +204,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _addListener: function(eventName) {
-      if (!this.isAttached || this.__listeningForActivate) {
-        return;
-      }
-
-      this.__listeningForActivate = true;
       this.listen(this, eventName, '_activateHandler');
     },
 
     _removeListener: function(eventName) {
       this.unlisten(this, eventName, '_activateHandler');
-      this.__listeningForActivate = false;
     },
 
     _activateEventChanged: function(eventName, old) {

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -145,7 +145,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     attached: function() {
       this._observer = this._observeItems(this);
       this._updateItems();
-      if (!this.selectedItem && this.selected) {
+      if (!this._shouldUpdateSelection) {
         this._updateSelected(this.attrForSelected,this.selected)
       }
       this._addListener(this.activateEvent);
@@ -198,6 +198,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     selectNext: function() {
       var index = (Number(this._valueToIndex(this.selected)) + 1) % this.items.length;
       this.selected = this._indexToValue(index);
+    },
+
+    get _shouldUpdateSelection() {
+      return this.selected != null;
     },
 
     _addListener: function(eventName) {
@@ -289,10 +293,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         this._updateItems();
 
-        if (this.selected != null) {
+        if (this._shouldUpdateSelection) {
           this._updateSelected();
         }
-      }.bind(this));
+      });
     },
 
     _activateHandler: function(e) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -153,10 +153,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             changeCount++;
           });
 
-          s2.appendChild(newItem);
+          Polymer.dom(s2).appendChild(newItem);
 
           Polymer.Base.async(function() {
-            s2.removeChild(newItem);
+            Polymer.dom(s2).removeChild(newItem);
 
             Polymer.Base.async(function() {
               expect(changeCount).to.be.equal(2);

--- a/test/basic.html
+++ b/test/basic.html
@@ -104,10 +104,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         s2 = fixture('basic');
       });
 
-      test('honors the attrForSelected attribute', function() {
-        assert.equal(s2.attrForSelected, 'id');
-        assert.equal(s2.selected, 'item2');
-        assert.equal(s2.selectedItem, document.querySelector('#item2'));
+      test('honors the attrForSelected attribute', function(done) {
+        Polymer.Base.async(function() {
+          assert.equal(s2.attrForSelected, 'id');
+          assert.equal(s2.selected, 'item2');
+          assert.equal(s2.selectedItem, document.querySelector('#item2'));
+          done();
+        });
       });
 
       test('allows assignment to selected', function() {

--- a/test/excluded-local-names.html
+++ b/test/excluded-local-names.html
@@ -70,17 +70,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
 
-      test('items', function() {
+      test('items', function(done) {
         test1._excludedLocalNames.span = 1;
         test2._excludedLocalNames.div = 1;
+        test1._updateItems();
+        test2._updateItems();
 
+        Polymer.Base.async(function() {
           var NOT_FOUND = -1;
           var items1 = test1.items.map(function(el) { return el.localName; });
           var items2 = test2.items.map(function(el) { return el.localName; });
 
           assert.equal(items1.indexOf('span'), NOT_FOUND);
           assert.equal(items2.indexOf('div'), NOT_FOUND);
+          done();
         });
+      });
 
     });
 

--- a/test/multi.html
+++ b/test/multi.html
@@ -66,6 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       setup(function () {
         s = fixture('test');
+        t = Polymer.dom(s).querySelector('[is="dom-repeat"]');
       });
 
       test('honors the multi attribute', function() {
@@ -161,6 +162,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(s.selectedItems[0].textContent, 'foo');
           done();
         });
+      });
+
+      test('updates selection when dom changes', function(done) {
+        var selectEventCounter = 0;
+
+        s = document.querySelector('#repeatedItems');
+
+        Polymer.Base.async(function() {
+          var firstChild = Polymer.dom(s).querySelector(':first-child');
+          var lastChild = Polymer.dom(s).querySelector(':last-child');
+
+          MockInteractions.tap(firstChild);
+          MockInteractions.tap(lastChild);
+
+          expect(s.selectedItems.length).to.be.equal(2);
+
+          t.pop('items');
+
+          Polymer.Base.async(function() {
+            expect(s.selectedItems.length).to.be.equal(1);
+          }, 1);
+        });
+
       });
 
       /* test('toggle multi from true to false', function() {

--- a/test/multi.html
+++ b/test/multi.html
@@ -167,7 +167,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('updates selection when dom changes', function(done) {
         var selectEventCounter = 0;
 
-        s = document.querySelector('#repeatedItems');
+        s = fixture('test');
 
         Polymer.Base.async(function() {
           var firstChild = Polymer.dom(s).querySelector(':first-child');
@@ -178,11 +178,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           expect(s.selectedItems.length).to.be.equal(2);
 
-          t.pop('items');
+          Polymer.dom(s).removeChild(lastChild);
 
           Polymer.Base.async(function() {
             expect(s.selectedItems.length).to.be.equal(1);
-          }, 1);
+            done();
+          });
         });
 
       });


### PR DESCRIPTION
This change does the following:
 - Removes a temporary patch obsoleted by https://github.com/Polymer/polymer/issues/2535
 - Replaces usage of MutationObserver with `Polymer.dom(...).observeNodes`

/cc @notwaldorf 

This branch is blocked by https://github.com/Polymer/polymer/pull/2548 being tagged. It is currently released on `polymer#master`, but until it is tagged these changes cannot be merged into `iron-selected#master`.