### PR TITLE
Closes paper-dropdown-menu if the already selected option is clicked.

### DIFF
--- a/iron-multi-selectable.html
+++ b/iron-multi-selectable.html
@@ -64,6 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.selectedValues = [value];
         }
       } else {
+        this.selected = -1;
         this.selected = value;
       }
     },


### PR DESCRIPTION
FIxes https://github.com/PolymerElements/paper-dropdown-menu/issues/72. I am hoping that a better fix exists, but at least this change reveals where the problem lies.