### PR TITLE
Enable manual force synchronous item updates.

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -113,6 +113,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       items: {
         type: Array,
         readOnly: true,
+        notify: true,
         value: function() {
           return [];
         }
@@ -201,6 +202,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this.selected = this._indexToValue(index);
     },
 
+    /**
+     * Force a synchronous update of the `items` property.
+     *
+     * NOTE: Consider listening for the `iron-items-changed` event to respond to
+     * updates to the set of selectable items after updates to the DOM list and
+     * selection state have been made.
+     *
+     * WARNING: If you are using this method, you should probably consider an
+     * alternate approach. Synchronously querying for items is potentially
+     * slow for many use cases. The `items` property will update asynchronously
+     * on its own to reflect selectable items in the DOM.
+     */
+    forceSynchronousItemUpdate: function() {
+      this._updateItems();
+    },
+
     get _shouldUpdateSelection() {
       return this.selected != null;
     },
@@ -285,18 +302,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // observe items change under the given node.
     _observeItems: function(node) {
       return Polymer.dom(node).observeNodes(function(mutations) {
+        this._updateItems();
+
+        if (this._shouldUpdateSelection) {
+          this._updateSelected();
+        }
+
         // Let other interested parties know about the change so that
         // we don't have to recreate mutation observers everywher.
         this.fire('iron-items-changed', mutations, {
           bubbles: false,
           cancelable: false
         });
-
-        this._updateItems();
-
-        if (this._shouldUpdateSelection) {
-          this._updateSelected();
-        }
       });
     },
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -145,7 +145,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(selectedEventCounter, 0);
       });
 
+      test('force synchronous item update', function() {
+        expect(s2.items.length).to.be.equal(5);
+        Polymer.dom(s2).appendChild(document.createElement('div'));
+        expect(s2.items.length).to.be.equal(5);
+        s2.forceSynchronousItemUpdate();
+        expect(s2.items.length).to.be.equal(6);
+      });
+
       suite('items changing', function() {
+        var s1;
+
+        setup(function() {
+          s1 = fixture('defaults');
+        });
+
         test('cause iron-items-changed to fire', function(done) {
           var newItem = document.createElement('div');
           var changeCount = 0;
@@ -166,6 +180,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done();
             }, 1);
           }, 1);
+        });
+
+        test('updates selected item', function(done) {
+          s1.addEventListener('iron-items-changed', function firstListener() {
+            s1.removeEventListener('iron-items-changed', firstListener);
+            var firstElementChild = Polymer.dom(s1).firstElementChild;
+            expect(firstElementChild).to.be.equal(s1.selectedItem);
+            expect(firstElementChild.classList.contains('iron-selected'))
+                .to.be.eql(true);
+            Polymer.dom(s1).removeChild(s1.selectedItem);
+
+            s1.addEventListener('iron-items-changed', function() {
+              firstElementChild = Polymer.dom(s1).firstElementChild;
+              expect(firstElementChild).to.be.equal(s1.selectedItem);
+              expect(firstElementChild.classList.contains('iron-selected'))
+                  .to.be.eql(true);
+              done();
+            });
+          });
+          s1.selected = 0;
         });
       });
 


### PR DESCRIPTION
A previous version of `iron-selector` broke a user expectation of
synchrony related to updates of the `items` property. This change
introduces a fallback that allows a user to force a synchronous update
to the `items` property.

In addition, this change makes the `items` property notify.