### PR TITLE
Fix test depending on `async` and `observeNodes` callbacks being interleaved.

### DIFF
--- a/test/multi.html
+++ b/test/multi.html
@@ -180,10 +180,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           Polymer.dom(s).removeChild(lastChild);
 
-          Polymer.Base.async(function() {
-            expect(s.selectedItems.length).to.be.equal(1);
-            done();
-          });
+          Polymer.dom.flush();
+
+          expect(s.selectedItems.length).to.be.equal(1);
+          expect(s.selectedItems[0]).to.be.equal(firstChild);
+
+          done();
         });
 
       });


### PR DESCRIPTION
`Polymer.Base.async` changes the text content of a node with an attached MutationObserver to get its callback called with microtask timing. `Polymer.dom(...).observeNodes` also uses a separate MutationObserver when available. `Polymer.Base.async`, because it only has one mutation observer, flushes all callbacks synchronously when its MutationObserver is called. So, all callbacks given to `async` occur before any other MutationObservers triggered after the first `async` call.