### PR TITLE
Fixes #57: `attr-for-selected` now always expects hyphenated names.

### DIFF
--- a/attr-for-selected-elements.html
+++ b/attr-for-selected-elements.html
@@ -1,0 +1,29 @@
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="attr-reflector">
+  <template>
+    <div>{{someAttr}}</div>
+  </template>
+  <script>
+    Polymer({
+      is: 'attr-reflector',
+
+      properties: {
+        someAttr: {
+          type: String,
+          value: "",
+          reflectToAttribute: true
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -46,8 +46,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     properties: {
 
       /**
-       * If you want to use the attribute value of an element for `selected` instead of the index,
-       * set this to the name of the attribute.
+       * If you want to use an attribute value or property of an element for
+       * `selected` instead of the index, set this to the name of the attribute
+       * or property. Hyphenated values are converted to camel case when used to
+       * look up the property of a selectable element. Camel cased values are
+       * *not* converted to hyphenated values for attribute lookup. It's
+       * recommended that you provide the hyphenated form of the name so that
+       * selection works in both cases. (Use `attr-or-property-name` instead of
+       * `attrOrPropertyName`.)
        */
       attrForSelected: {
         type: String,
@@ -288,7 +294,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _valueForItem: function(item) {
-      var propValue = item[this.attrForSelected];
+      var propValue = item[Polymer.CaseMap.dashToCamelCase(this.attrForSelected)];
       return propValue != undefined ? propValue : item.getAttribute(this.attrForSelected);
     },
 

--- a/test/attr-for-selected.html
+++ b/test/attr-for-selected.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<!--
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+<head>
+
+  <title>iron-selector attr-for-selected</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+  <link rel="import" href="../attr-for-selected-elements.html">
+
+  <link rel="import" href="../iron-selector.html">
+
+  <style>
+    .iron-selected {
+      background: #ccc;
+    }
+
+    .my-selected {
+      background: red;
+    }
+  </style>
+
+</head>
+<body>
+
+  <test-fixture id="inlineAttributes">
+    <template>
+      <iron-selector attr-for-selected="some-attr">
+        <div some-attr="value0">Item 0</div>
+        <div some-attr="value1">Item 1</div>
+        <div some-attr="value2">Item 2</div>
+      </iron-selector>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="reflectedProperties">
+    <template>
+      <iron-selector attr-for-selected="some-attr">
+        <attr-reflector>Item 0</attr-reflector>
+        <attr-reflector>Item 1</attr-reflector>
+        <attr-reflector>Item 2</attr-reflector>
+      </iron-selector>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="mixedPropertiesAndAttributes">
+    <template>
+      <iron-selector attr-for-selected="some-attr">
+        <attr-reflector>Item 0</attr-reflector>
+        <attr-reflector>Item 1</attr-reflector>
+        <div some-attr="value2">Item 2</div>
+        <div some-attr="value3">Item 3</div>
+        <attr-reflector>Item 4</attr-reflector>
+        <div some-attr="value5">Item 5</div>
+      </iron-selector>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('inline attributes', function() {
+      var selector;
+      var items;
+
+      setup(function () {
+        selector = fixture('inlineAttributes');
+        items = Array.prototype.slice.apply(selector.querySelectorAll('div[some-attr]'));
+      });
+
+      test('selecting value programatically selects correct item', function() {
+        selector.select('value1');
+        assert.equal(selector.selectedItem, items[1]);
+      });
+
+      test('selecting item sets the correct selected value', function(done) {
+        MockInteractions.downAndUp(items[2], function() {
+          assert.equal(selector.selected, 'value2');
+          done();
+        });
+      });
+    });
+
+    suite('reflected properties as attributes', function() {
+      var selector;
+      var items;
+
+      setup(function () {
+        selector = fixture('reflectedProperties');
+        items = Array.prototype.slice.apply(selector.querySelectorAll('attr-reflector'));
+        for (var i = 0; i < items.length; i++) {
+          items[i].someAttr = "value" + i;
+        }
+      });
+
+      test('selecting value programatically selects correct item', function() {
+        selector.select('value1');
+        assert.equal(selector.selectedItem, items[1]);
+      });
+
+      test('selecting item sets the correct selected value', function(done) {
+        MockInteractions.downAndUp(items[2], function() {
+          assert.equal(selector.selected, 'value2');
+          done();
+        });
+      });
+    });
+
+    suite('mixed properties and inline attributes', function() {
+      var selector;
+      var items;
+
+      setup(function () {
+        selector = fixture('mixedPropertiesAndAttributes');
+        items = Array.prototype.slice.apply(selector.querySelectorAll('attr-reflector, div[some-attr]'));
+        for (var i = 0; i < items.length; i++) {
+          items[i].someAttr = "value" + i;
+        }
+      });
+
+      test('selecting value programatically selects correct item', function() {
+        for (var i = 0; i < items.length; i++) {
+          selector.select('value' + i);
+          assert.equal(selector.selectedItem, items[i]);
+        }
+      });
+
+      test('selecting item sets the correct selected value', function(done) {
+        var i = 0;
+
+        function testSelectItem(i) {
+          if (i >= items.length) {
+            done();
+            return;
+          }
+
+          MockInteractions.downAndUp(items[i], function() {
+            assert.equal(selector.selected, 'value' + i);
+
+            testSelectItem(i + 1);
+          });
+        }
+
+        testSelectItem(i);
+      });
+    });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
Continuation of #101. (Fixes #57.)