### PR TITLE
Rephrase documentation for fallbackSelection.

### DIFF
--- a/iron-selector.html
+++ b/iron-selector.html
@@ -38,7 +38,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div name="zot">Zot</div>
       </iron-selector>
 
-  If no matching element is found using `attForSelected`, use `fallbackSelection` as fallback.
+  You can specify a default fallback with `fallbackSelection` in case the `selected` attribute does
+  not match the `attrForSelected` attribute of any elements.
 
   Example:
 


### PR DESCRIPTION
The motivation here is a typo in the paragraph (attrForSelected), but also rephrase it a little bit
as an attempt to make it clearer.