### PR TITLE
default next/prev to first/last when no selection

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -186,8 +186,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     selectPrevious: function() {
       var length = this.items.length;
-      var index =
+      var index = length - 1;
+      if(this.selected !== undefined) {
+        index =
           (Number(this._valueToIndex(this.selected)) - 1 + length) % length;
+      }
       this.selected = this._indexToValue(index);
     },
 
@@ -197,8 +200,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * @method selectNext
      */
     selectNext: function() {
-      var index =
+      var index = 0;
+      if(this.selected !== undefined) {
+        index =
           (Number(this._valueToIndex(this.selected)) + 1) % this.items.length;
+      }
       this.selected = this._indexToValue(index);
     },
 

--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -187,9 +187,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     selectPrevious: function() {
       var length = this.items.length;
       var index = length - 1;
-      if(this.selected !== undefined) {
-        index =
-          (Number(this._valueToIndex(this.selected)) - 1 + length) % length;
+      if (this.selected !== undefined) {
+        index = (Number(this._valueToIndex(this.selected)) - 1 + length) % length;
       }
       this.selected = this._indexToValue(index);
     },
@@ -201,9 +200,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      */
     selectNext: function() {
       var index = 0;
-      if(this.selected !== undefined) {
+      if (this.selected !== undefined) {
         index =
-          (Number(this._valueToIndex(this.selected)) + 1) % this.items.length;
+            (Number(this._valueToIndex(this.selected)) + 1) % this.items.length;
       }
       this.selected = this._indexToValue(index);
     },

--- a/test/next-previous.html
+++ b/test/next-previous.html
@@ -95,6 +95,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assertAndSelect('selectPrevious', 2);
         assert.equal(s.selected, 1);
       });
+
+      test('selectNext from unselected', function() {
+        s.selected = undefined;
+        assertAndSelect('selectNext', undefined);
+        assert.equal(s.selected, 0);
+      });
+
+      test('selectPrevious from unselected', function() {
+        s.selected = undefined;
+        assertAndSelect('selectPrevious', undefined);
+        assert.equal(s.selected, 2);
+      });
     });
 
     suite('next/previous attrForSelected', function() {


### PR DESCRIPTION
Fixes #124.

When no selection has been made:
- `selectNext` will select the first item
- `selectPrevious` will select the last item

If you're wondering why I check that `selected !== undefined`, it is so (if somehow) non-existent selections are made, nothing will be selected.
