### PR TITLE
add all required files - fixing #131

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,12 @@
   "description": "Manages a set of elements that can be selected",
   "private": true,
   "license": "http://polymer.github.io/LICENSE.txt",
-  "main": "iron-selector.html",
+  "main": [
+    "iron-selector.html",
+    "iron-multi-selectable.html",
+    "iron-selectable.html",
+    "iron-selection.html"
+  ],
   "authors": [
     "The Polymer Authors"
   ],


### PR DESCRIPTION
~~I also change the `private` field to **false**, since it makes no sense to have a public published project marked as private.~~ - reverted back to **true**

Another issue is that the relative href expect a folder structure that is not given by the project (e.g. `../polymer/polymer.html`). This is problematic but out of scope for this PR.