### PR TITLE
Make `_updateSelected` observes `items` as well

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -153,7 +153,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     observers: [
       '_updateAttrForSelected(attrForSelected)',
-      '_updateSelected(selected)',
+      '_updateSelected(selected, items)',
       '_checkFallback(fallbackSelection)'
     ],
 


### PR DESCRIPTION
When the items are dynamically generated, the various `selected` should be updated when the items are changed as well.