### PR TITLE
Enhancement - Add select / deselect lifecycle callbacks. #140

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -338,6 +338,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
       this._selectionChange();
       this.fire('iron-' + (isSelected ? 'select' : 'deselect'), {item: item});
+      // Check for callback function in the selected / deselected item and call it if it exists.
+      if(typeof item[isSelected ? 'selected' : 'deselected']  === 'function') {
+        item[isSelected ? 'selected' : 'deselected']();
+      }
     },
 
     _selectionChange: function() {


### PR DESCRIPTION
Main reason for this would be the iron-pages view switching like shown in the starter-kit.
e.g. If i have an Video on an view element, you want it to stop it on deselect.
Or reloading ajax requests on select, or resetting form data to blank, ...