### PR TITLE
Add selectedPropertyValue to dynamically set property

### DIFF
--- a/iron-selectable.html
+++ b/iron-selectable.html
@@ -115,6 +115,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       /**
+       * The value of the property to set when an item is selected. The name
+       * of the property is this.selectedAttribute.
+       */
+      selectedPropertyValue: {
+        type: Object,
+        value: null
+      },
+
+      /**
        * Default fallback if the selection based on selected with `attrForSelected`
        * is not found.
        */
@@ -154,7 +163,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     observers: [
       '_updateAttrForSelected(attrForSelected)',
       '_updateSelected(selected)',
-      '_checkFallback(fallbackSelection)'
+      '_checkFallback(fallbackSelection)',
+      '_updatePropertyValue(selectedItem, selectedAttribute, selectedPropertyValue)'
     ],
 
     created: function() {
@@ -336,8 +346,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (this.selectedAttribute) {
         this.toggleAttribute(this.selectedAttribute, isSelected, item);
       }
+      if (this.selectedPropertyValue) {
+        item[this.selectedAttribute] = this.selectedPropertyValue;
+      }
       this._selectionChange();
       this.fire('iron-' + (isSelected ? 'select' : 'deselect'), {item: item});
+    },
+
+    _updatePropertyValue: function(selectedItem, selectedAttribute, propertyValue) {
+      if (selectedAttribute && propertyValue) {
+        selectedItem[selectedAttribute] = propertyValue;
+      }
     },
 
     _selectionChange: function() {

--- a/test/selected-attribute.html
+++ b/test/selected-attribute.html
@@ -87,6 +87,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(s.children[4].hasAttribute('myattr'));
       });
 
+      test('custom selectedAttribute with value', function() {
+        var value = { foo: 'bar' };
+        s.selectedPropertyValue = value
+        // set selectedAttribute
+        s.selectedAttribute = 'myattr';
+        // check selected attribute (should not be there)
+        assert.isFalse(s.children[4].hasAttribute('myattr'));
+        // set selected
+        s.selected = 4;
+        // now selected attribute should be there
+        assert.isTrue(s.children[4].hasAttribute('myattr'));
+        assert.deepEqual(s.children[4]['myattr'], value);
+
+        s.selectedPropertyValue = 'foo';
+        assert.deepEqual(s.children[4]['myattr'], 'foo');
+      });
+
     });
 
     suite('changing attrForSelected', function() {


### PR DESCRIPTION
Please see https://github.com/PolymerElements/app-route/issues/164 for the motivation of this PR. In general, it is not possible to dynamically change the value of `selected-attribute` and alike. Therefore this PR introduces a new property that does so. Since attribute values can not cope with objects (which was the original usecase) I decided to dircectly set it as property instead.

Fixes https://github.com/PolymerElements/app-route/issues/164