### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-selector.js
+++ b/iron-selector.js
@@ -81,6 +81,7 @@ Example:
 Polymer({
 
   is: 'iron-selector',
+  _template: null,
 
   behaviors: [IronMultiSelectableBehavior]
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336